### PR TITLE
Enumerate the history of a document.

### DIFF
--- a/spec/relaxo/database_spec.rb
+++ b/spec/relaxo/database_spec.rb
@@ -84,4 +84,20 @@ RSpec.describe Relaxo::Database do
 			expect(dataset.each('test').count).to be == 10
 		end
 	end
+	
+	it "can enumerate commit history of a document" do
+		10.times do |id|
+			database.commit(message: "revising the document #{id}") do |changeset|
+				oid = changeset.append("revision \##{id} of this document")
+				changeset.write('test/doot.txt', oid)
+			end
+		end
+		
+		database.commit(message: "unrelated commit") do |changeset|
+			oid = changeset.append("unrelated document")
+			changeset.write('test/unrelated.txt', oid)
+		end
+		
+		expect(database.history('test/doot.txt').count).to be == 10
+	end
 end


### PR DESCRIPTION
@ioquatix what do you think about this sort of functionality? Being able to look at all the times a document/object was changed from when it was created to when it gets deleted, I wrote a spec for it too.

You can only see the modifications in the parent branches of the latest commit though.

This is of course completely incapable of detecting when an object has moved/renamed, but I don't see how that situation would arise from the intended use of relaxo.